### PR TITLE
tests: add tests for disabling describers

### DIFF
--- a/src/fetchSpy.ts
+++ b/src/fetchSpy.ts
@@ -6,13 +6,15 @@ export const successResponse = (text?: any, status: number = 200): Partial<Respo
   };
 };
 
-export const failureResponse = (text?: any, status: number = 500): Partial<Response> => {
-  return {
-    ok: false,
-    status: status,
-    text: () => Promise.resolve(text)
-  };
-};
+// not used for now, and as such this should be commented out, also to better reflect
+// the actual test coverage
+// export const failureResponse = (text?: any, status: number = 500): Partial<Response> => {
+//   return {
+//     ok: false,
+//     status: status,
+//     text: () => Promise.resolve(text)
+//   };
+// };
 
 export const fetchSpy = (response: Partial<Response>) => {
   return jest

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -66,5 +66,16 @@ describe('describe function', () => {
       expect(description.layers?.[0].type).toStrictEqual('unknown');
     });
   });
+  test('disabling viewDescriber', async () => {
+    let description = await describeOlMap(map, {viewDescriber: null});
+    let emptyViewDescription = {};
+    expect(description.view).toStrictEqual(emptyViewDescription);
+  });
+  test('disabling layerDescriber', async () => {
+    let description = await describeOlMap(map, {layerDescriber: null});
+    let emptyLayerDescription = {details: null, source: '', type: ''};
+    let expected = [emptyLayerDescription, emptyLayerDescription];
+    expect(description.layers).toStrictEqual(expected);
+  });
 });
 


### PR DESCRIPTION
The title says it all. This only affects the tests, so I am going to merge without proper review.