### PR TITLE
Fix link to verbose example in wms.html example file

### DIFF
--- a/examples/wms.html
+++ b/examples/wms.html
@@ -10,7 +10,7 @@
     <div id="header">
       <h1>Basic WMS layer example</h1>
       <p>This example focusses on a basic description of WMS layers. See also
-        <a href="../wms-verbose.html">the verbose WMS example</a>, for a more detailed approach,
+        <a href="./wms-verbose.html">the verbose WMS example</a>, for a more detailed approach,
         please.</p>
       <p>Please interact with the map below and see how the description changes accordingly. The text that is displayed below the map is also set as <a href="https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-description"><code>aria-description</code></a> of the map's <code>div</code>-element in order to increase accessibility.</p>
     </div>


### PR DESCRIPTION
Fixes the link to the verbose WMS example in `wms.html` example file.